### PR TITLE
V1.4.0

### DIFF
--- a/docs/advanced-developing-plugins.md
+++ b/docs/advanced-developing-plugins.md
@@ -1,0 +1,157 @@
+---
+id: advanced-developing-plugins
+title: Developing plugins
+---
+
+## Plugins
+
+You can develop your own plugins for the mocks server to provide more interfaces, ~~add more ways of defining fixtures or behaviors~~ _(not yet available)_, etc.
+
+### Plugins lifecycle
+
+Plugins should contain __three main methods__, which will receive the instance of the Mocks Server core. Please read the [programmatic usage chapter](advanced-programmatic-usage.md) to know how to interact with the core.
+
+#### `register(core)`
+
+This method will be called for registering the plugin during the Mocks Server initialization, before `options` have been initialized.
+
+Here you should register your own custom `options` using the `core.addCustomSetting` method, register your own custom express routers using the `core.addCustomRouter` method, etc.
+
+You should never access here to the `core.settings` methods, are they are not still ready in this phase, which was defined with the intention of letting the plugins to add their own settings.
+
+> If you define your plugin as a Class, the `constructor` will be equivalent to defining a `register` method. If you define your plugin as a function, it will be called during the plugins registration, so you could also omit the `register` method.
+
+#### `init(core)`
+
+This method will be called when mocks server settings are ready. Here you already can access to the `core.settings` to get the user options, and act in consequence. Here you should also add your listeners to the core events, such as `core.onChangeSettings`, `core.onLoadMocks`, etc.
+
+#### `start(core)`
+
+When this method is called, the mocks server is already started and listening to requests, and the files watcher is observing for changes too.
+
+### Example
+
+Here you have an example of how a plugin is defined. Consult the [Mocks Server programmatic usage chapter](advanced-programmatic-usage.md) for further info:
+
+```javascript
+const { Core } = require("@mocks-server/core");
+
+class Plugin {
+  constructor(core) {
+    core.addCustomSetting({
+      name: "traceBehaviors",
+      type: "boolean",
+      description: "Trace behaviors changes",
+      default: true
+    });
+
+    this._core = core;
+    this._onLoadMocks = this._onLoadMocks.bind(this);
+    this._onChangeSettings = this._onChangeSettings.bind(this);
+  }
+
+  init(core) {
+    this._enabled = core.settings.get("traceBehaviors");
+    this._removeLoadMocksListener = core.onLoadMocks(this.onLoadMocks);
+    this._removeChangeSettingsListener = core.onLoadMocks(this.onChangeSettings);
+    core.tracer.debug(`traceBehaviors initial value is ${core.settings.get("traceBehaviors")}`);
+  }
+
+  start(core) {
+    this._started = true;
+    core.tracer.debug("traceBehaviors plugin started");
+  }
+
+  _onChangeSettings(settings) {
+    if (settings.hasOwnProperty("traceBehaviors")) {
+      this._enabled = settings.traceBehaviors;
+    }
+  }
+
+  _onLoadMocks() {
+    if (this._enabled && this._started) {
+      this._core.tracer.info(
+        `Mocks have been reloaded, now are ${this._core.behaviors.count} available`
+      );
+    }
+  }
+}
+
+const server = new Core({
+  onlyProgrammaticOptions: false,
+  plugins: [Plugin]
+});
+
+server
+  .init({
+    log: "debug"
+  })
+  .then(server.start);
+```
+
+### Plugins formats
+
+The methods can be defined in a plain `object`, as methods of a `Class` or even using a `function` returning an object containing them.
+
+Next examples show how each format should be defined:
+
+#### Plugin as a `Class`
+
+```javascript
+export default class Plugin {
+  constructor(core) {
+    // Do your register stuff here
+  }
+
+  register(core) {
+    // You should omit this method if you already did your register stuff in the constructor
+  }
+
+  init(core) {
+    // Do your initialization stuff here
+  }
+
+  start(core) {
+    // Do your start stuff here
+  }
+}
+```
+
+#### Plugin as a `function`
+
+```javascript
+const plugin = core => {
+  // Do your register stuff here
+  return {
+    register: core => {
+      // You should omit this method if you already did your register stuff
+    },
+    init: core => {
+      // Do your initialization stuff here
+    },
+    start: core => {
+      // Do your start stuff here
+    }
+  };
+};
+
+export default plugin;
+```
+
+#### Plugin as an `object`
+
+```javascript
+const plugin = {
+  register: core => {
+    // Do your register stuff here
+  },
+  init: core => {
+    // Do your initialization stuff here
+  },
+  start: core => {
+    // Do your start stuff here
+  }
+};
+
+export default plugin;
+```

--- a/docs/advanced-programmatic-usage.md
+++ b/docs/advanced-programmatic-usage.md
@@ -47,13 +47,13 @@ server
 * `start()`. Starts the mocks server and the files watcher. Returns a promise.
 * `stop()`. Stops the mocks server and the files watcher. Returns a promise.
 * `restart()`. Restarts the mocks server.
-* `onLoadFiles(callback)`. Adds a callback to be executed when mocks files are loaded.
+* `onLoadFiles(callback)`. Adds a callback to be executed when mocks files are loaded. Returns a function for removing the added calback.
 	* `callback([loadedFiles])`: `<Function>`
 		* `loadedFiles`: `<Object>` Information about loaded files. Still not processed as "mocks" objects.
-* `onLoadMocks(callback)`. Adds a callback to be executed when mocks are loaded.
+* `onLoadMocks(callback)`. Adds a callback to be executed when mocks are loaded. Returns a function for removing the added calback.
 	* `callback([loadedMocks])`: `<Function>`
 		* `loadedMocks`: `<Object>` Information about loaded mocks. Already processed as "mocks" objects, ready to be served by the mocks server.
-* `onChangeSettings(callback)`. Adds a callback to be executed when settings are changed.
+* `onChangeSettings(callback)`. Adds a callback to be executed when settings are changed. Returns a function for removing the added calback.
 	* `callback([changedSettings])`: `<Function>`
 		* `changedSettings`: `<Object>` Settings properties that have changed, with new values.
 * `addCustomSetting(customSetting)` Registers a new setting (which will be available also as an "option" during initialization). Has to be called before the `core.init` method is called. (It should be usually used by Plugins in their `register` method)
@@ -63,7 +63,9 @@ server
 		* `description`: `<String>` Used for giving help to the user in command line arguments, for example.
 		* `default`: `<Any>` Default value for the new option.
 		* `parse`: `<Function>` Custom parser for the option when it is defined using command line arguments.
-* `addCustomRouter` TODO
+* `addCustomRouter(path, expressRouter)`. Adds a custom [express router](https://expressjs.com/es/guide/routing.html) to the mocks server. Custom routers will be added just before the middleware that serves the fixtures, so if a custom router path matches with a fixture path, the first one will have priority.
+		* `path`: `<String>` Api path for the custom router.
+		* `expressRouter`: `<Express Router>` Instance of an [express router](https://expressjs.com/es/guide/routing.html).
 
 ###### Getters
 
@@ -81,5 +83,6 @@ server
 	* `get(key)`. Returns current value of an specific setting.
 		* `key`: `<String>`The name of the setting to be returned. Equivalent to [option](configuration-options.md#main-options) name.
 * `serverError`. If mocks server throws an unexpected error, it is available at this getter.
-* `behaviors` TODO
-
+* `behaviors`. Returns methods and getters related to currently available behaviors. We encourage to not use this getter by the moment, as it is still in development and the api will change in next minor releases. Properties that are going to be maintained and can be used without danger are:
+	* `count`. Getter returning total number of behaviors available.
+	* `names`. Getter returning an array with all behavior names.

--- a/docs/configuration-command-line-arguments.md
+++ b/docs/configuration-command-line-arguments.md
@@ -3,21 +3,9 @@ id: configuration-command-line-arguments
 title: Command line arguments
 ---
 
-## Options
+## How to define options using command line arguments
 
-* `port`: `<Number>` Por number for the Mocks Server to be listening.
-* `host`: `<String>` Host for the server. Default is "0.0.0.0" (Listen to any local host).
-* `log`: `<String>` Logs level. Can be one of "silly", "debug", "verbose", "info", "warn", "error".
-* `watch`: `<Boolean>` Watch behaviors folder and restart server on changes. Default is `true`.
-* `behavior`: `<String>` Default selected behavior when server is started.
-* `delay`: `<Number` Responses delay time in milliseconds.
-* `behaviors`: `Path as <String>` Path to a folder containing behaviors to be used by the server.
-* `recursive`: `<Boolean>` Search for behaviors recursively in subfolders. Watch is not affected by this option, it is always recursive.
-* `cli`: `<Boolean>` Start interactive CLI. Default is `true`.
-
-## How to define options
-
-Supossing you have a `mocks-server` script added to your `package.json` file, as seen in the [get started chapter](get-started-intro.md#installation), you can define options directly in the npm script:
+Supossing you have a `mocks-server` script added to your `package.json` file, as seen in the [get started chapter](get-started-intro.md#installation), then you can define options directly in the npm script using arguments:
 
 ```json
 {
@@ -27,10 +15,18 @@ Supossing you have a `mocks-server` script added to your `package.json` file, as
 }
 ```
 
-Or you can pass options when calling to the npm command:
+Or you can define options when calling to the npm command:
 
 ```bash
 npm run mocks-server -- --delay=300
 ```
 
 > Note the usage of two double dashes. Anything after the first double dashes is not an option of npm, but a parameter for the script that npm executes.
+
+## Plugins options
+
+Options added by registered plugins can be defined also using command line arguments. Supossing you have registered a plugin which add a new option called "language", then you'll be able to run:
+
+```bash
+npm run mocks-server -- --language=Es-es
+```

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -1,0 +1,26 @@
+---
+id: configuration-options
+title: Options
+---
+
+This chapter describes all available options in the [@mocks-server/main package distribution](https://www.npmjs.com/package/@mocks-server/main), which includes an NPM binary file and plugins for administrating the server using a REST API and an interactive CLI:
+
+## Main options
+
+* `port`: `<Number>` Por number for the Mocks Server to be listening.
+* `host`: `<String>` Host for the server. Default is "0.0.0.0" (Listen to any local host).
+* `log`: `<String>` Logs level. Can be one of "silly", "debug", "verbose", "info", "warn", "error".
+* `watch`: `<Boolean>` Watch behaviors folder and restart server on changes. Default is `true`.
+* `behavior`: `<String>` Default selected behavior when server is started.
+* `delay`: `<Number` Responses delay time in milliseconds.
+* `behaviors`: `Path as <String>` Path to a folder containing behaviors to be used by the server.
+
+## Plugins extra options
+
+* `cli`: `<Boolean>` Start interactive CLI. Default is `true`.
+
+> These extra options are added by the [@mocks-server/plugin-admin-api](https://www.npmjs.com/package/@mocks-server/plugin-admin-api) and the [@mocks-server/plugin-inquirer-cli](https://www.npmjs.com/package/@mocks-server/plugin-inquirer-cli) plugins, which are included in the [@mocks-server/main package distribution](https://www.npmjs.com/package/@mocks-server/main).
+
+Each plugin can add his own options when it is registered in the mocks-server. If you are starting the server programmatically using the [@mocks-server/core](https://www.npmjs.com/package/@mocks-server/core) without adding plugins, only "Main options" will be available.
+
+For another plugins options, please refer to their own documentation.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mocks-server-website",
   "description": "Mocks server documentation website",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "private": true,
   "author": "Javier Brea",
   "license": "MIT",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,7 +3,7 @@
     "Welcome": ["welcome-about-docs"],
     "Getting started": ["get-started-intro", "get-started-fixtures", "get-started-behaviors"],
     "Tutorials": ["tutorials-static", "tutorials-dynamic"],
-    "Configuration": ["configuration-command-line-arguments", "configuration-interactive-cli", "configuration-rest-api"],
+    "Configuration": ["configuration-options", "configuration-command-line-arguments", "configuration-interactive-cli", "configuration-rest-api"],
     "Advanced": ["advanced-programmatic-usage"]
   }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -4,6 +4,6 @@
     "Getting started": ["get-started-intro", "get-started-fixtures", "get-started-behaviors"],
     "Tutorials": ["tutorials-static", "tutorials-dynamic"],
     "Configuration": ["configuration-options", "configuration-command-line-arguments", "configuration-interactive-cli", "configuration-rest-api"],
-    "Advanced": ["advanced-programmatic-usage"]
+    "Advanced": ["advanced-programmatic-usage", "advanced-developing-plugins"]
   }
 }


### PR DESCRIPTION
- Add documentation about plugins.
- Change documentation about programmatic usage. Now it explains how to use the @mocks-server/core package.
- Split configuration chapter into "options" and "command-line-arguments"
