### PR TITLE
fix: change `only` option to an array

### DIFF
--- a/versioned_docs/version-4.0.0/guides/using-babel.md
+++ b/versioned_docs/version-4.0.0/guides/using-babel.md
@@ -90,9 +90,9 @@ module.exports = {
       enabled: true,
       // highlight-start
       options: {
-        only: (filePath) => {
+        only: [(filePath) => {
           return filePath.includes("/mocks/") || filePath.includes("/my-folder-to-include/");
-        },
+        }],
       },
       // highlight-end
     },


### PR DESCRIPTION
`only` no longer support just a function as value, more about it here https://github.com/babel/babel/issues/8350